### PR TITLE
chore: migrate Umami analytics domain to analytics.ajanderson.net

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>aztec-web-inspector</title>
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://analytics.ajanderson.net https://fastly.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://analytics.ajanderson.net https://fastly.jsdelivr.net; worker-src 'self' blob:;" />
-    <script defer src="https://analytics.ajanderson.net/script.js"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://analytics.vasttrafiklive.com https://fastly.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://analytics.vasttrafiklive.com https://fastly.jsdelivr.net; worker-src 'self' blob:;" />
+    <script defer src="https://analytics.vasttrafiklive.com/script.js"
             data-website-id="61ee5b66-31ba-40ee-87d0-358b61c4b662"
-            integrity="sha384-6PHtXKae10+dZuA/fcmjkSTDco+NPBE5fZ4eS/Em2lVIsS6FdDZIgs06MBJLEcSW"
             crossorigin="anonymous"></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>aztec-web-inspector</title>
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://analytics.vasttrafiklive.com https://fastly.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://analytics.vasttrafiklive.com https://fastly.jsdelivr.net; worker-src 'self' blob:;" />
-    <script defer src="https://analytics.vasttrafiklive.com/script.js"
+          content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://analytics.ajanderson.net https://fastly.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://analytics.ajanderson.net https://fastly.jsdelivr.net; worker-src 'self' blob:;" />
+    <script defer src="https://analytics.ajanderson.net/script.js"
             data-website-id="61ee5b66-31ba-40ee-87d0-358b61c4b662"
             crossorigin="anonymous"></script>
   </head>


### PR DESCRIPTION
Full cutover of the self-hosted Umami analytics domain from `analytics.vasttrafiklive.com` to `analytics.ajanderson.net`.

## Changes
- **index.html**: CSP `script-src` + `connect-src` allowlist entries and the tracking `<script src>` host → new domain. Both CSP and src must match or the script is blocked.

## Server-side state (already live)
- Umami now serves on `https://analytics.ajanderson.net` (Let's Encrypt cert issued; `/api/heartbeat` → `{"ok":true}`). Old hostname no longer routes.

## Deploy note
This site deploys via the `production` branch → GitHub Actions → SCP to fuji. Merging this to `main` is not enough; the change must reach `production` to redeploy. Until then the live site loads a dead script host and reports no analytics.